### PR TITLE
Adding context propagation to net/http server instrumentation

### DIFF
--- a/include/alloc.h
+++ b/include/alloc.h
@@ -60,7 +60,7 @@ static __always_inline void* write_target_data(void* data, s32 size) {
     long success = bpf_probe_write_user(target, data, size);
     if (success == 0) {
         s32 start_index = 0;
-        u64 updated_start = start + size;
+        u64 updated_start = start + size + (8 - (size % 8));
         bpf_map_update_elem(&alloc_map, &start_index, &updated_start, BPF_ANY);
         return target;
     } else {

--- a/include/go_types.h
+++ b/include/go_types.h
@@ -5,13 +5,13 @@
 
 struct go_string {
     char* str;
-    s32 len;
+    s64 len;
 };
 
 struct go_slice {
     void* array;
-    s32 len;
-    s32 cap;
+    s64 len;
+    s64 cap;
 };
 
 struct go_slice_user_ptr {
@@ -23,6 +23,13 @@ struct go_slice_user_ptr {
 struct go_iface {
     void* tab;
     void* data;
+};
+
+struct map_bucket {
+    char tophash[8];
+    struct go_string keys[8];
+    struct go_slice values[8];
+    void* overflow;
 };
 
 static __always_inline struct go_string write_user_go_string(char* str, u32 len) {

--- a/pkg/inject/offset_results.json
+++ b/pkg/inject/offset_results.json
@@ -431,6 +431,432 @@
         },
         {
           "struct": "net/http.Request",
+          "field_name": "Header",
+          "offsets": [
+            {
+              "offset": 56,
+              "version": "1.19.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.19"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.18"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.17"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.16"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.17"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.16"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.12"
+            }
+          ]
+        },
+        {
+          "struct": "net/http.Request",
           "field_name": "ctx",
           "offsets": [
             {

--- a/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
@@ -1,11 +1,14 @@
 #include "arguments.h"
 #include "span_context.h"
 #include "go_context.h"
+#include "go_types.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
 #define MAX_SIZE 100
 #define MAX_CONCURRENT 50
+#define W3C_KEY_LENGTH 11
+#define W3C_VAL_LENGTH 55
 
 struct http_request_t {
     u64 start_time;
@@ -13,6 +16,7 @@ struct http_request_t {
     char method[MAX_SIZE];
     char path[MAX_SIZE];
     struct span_context sc;
+    struct span_context psc;
 };
 
 struct {
@@ -26,11 +30,81 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 } events SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(struct map_bucket));
+	__uint(max_entries, 1);
+} golang_mapbucket_storage_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(struct span_context));
+	__uint(max_entries, 1);
+} parent_span_context_storage_map SEC(".maps");
+
 // Injected in init
 volatile const u64 method_ptr_pos;
 volatile const u64 url_ptr_pos;
 volatile const u64 path_ptr_pos;
 volatile const u64 ctx_ptr_pos;
+volatile const u64 headers_ptr_pos;
+
+static __always_inline struct span_context* extract_context_from_req_headers(void* headers_ptr_ptr) {
+    void* headers_ptr;
+    bpf_probe_read(&headers_ptr, sizeof(headers_ptr), headers_ptr_ptr);
+    u64 headers_count = 0;
+    bpf_probe_read(&headers_count, sizeof(headers_count), headers_ptr);
+    if (headers_count == 0) {
+        return NULL;
+    }
+    unsigned char log_2_bucket_count;
+    bpf_probe_read(&log_2_bucket_count, sizeof(log_2_bucket_count), headers_ptr + 9);
+    u64 bucket_count = 1 << log_2_bucket_count;
+    void* header_buckets;
+    bpf_probe_read(&header_buckets, sizeof(header_buckets), headers_ptr + 16);
+    u32 map_id = 0;
+    struct map_bucket* map_value = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+    if (!map_value) {
+        return NULL;
+    }
+    // Currently iterating only over the first bucket
+    if (bucket_count >= 2) {
+        bucket_count = 1;
+    }
+    for (u64 j=0; j<bucket_count; j++) {
+        bpf_probe_read(map_value, sizeof(struct map_bucket), header_buckets + (j * sizeof(struct map_bucket)));
+        for (u64 i=0; i<8; i++) {
+            if (map_value->tophash[i] == 0) {
+                continue;
+            }
+            if (map_value->keys[i].len != W3C_KEY_LENGTH) {
+                continue;
+            }
+            char current_header_key[W3C_KEY_LENGTH];
+            bpf_probe_read(current_header_key, sizeof(current_header_key), map_value->keys[i].str);
+            if (!bpf_memcmp(current_header_key, "traceparent", W3C_KEY_LENGTH) && !bpf_memcmp(current_header_key, "Traceparent", W3C_KEY_LENGTH)) {
+               continue;
+            }
+            void* traceparent_header_value_ptr = map_value->values[i].array;
+            struct go_string traceparent_header_value_go_str;
+            bpf_probe_read(&traceparent_header_value_go_str, sizeof(traceparent_header_value_go_str), traceparent_header_value_ptr);
+            if (traceparent_header_value_go_str.len != W3C_VAL_LENGTH) {
+                continue;
+            }
+            char traceparent_header_value[W3C_VAL_LENGTH];
+            bpf_probe_read(&traceparent_header_value, sizeof(traceparent_header_value), traceparent_header_value_go_str.str);
+            struct span_context* parent_span_context = bpf_map_lookup_elem(&parent_span_context_storage_map, &map_id);
+            if (!parent_span_context) {
+                return NULL;
+            }
+            w3c_string_to_span_context(traceparent_header_value, parent_span_context);
+            return parent_span_context;
+        }
+    }
+    return NULL;
+}
 
 // This instrumentation attaches uprobe to the following function:
 // func (mux *ServeMux) ServeHTTP(w ResponseWriter, r *Request)
@@ -66,9 +140,15 @@ int uprobe_ServerMux_ServeHTTP(struct pt_regs *ctx) {
     // Get Request.ctx
     void *ctx_iface = 0;
     bpf_probe_read(&ctx_iface, sizeof(ctx_iface), (void *)(req_ptr+ctx_ptr_pos+8));
-
+    struct span_context* parent_ctx = extract_context_from_req_headers(req_ptr+headers_ptr_pos);
+    if(parent_ctx != NULL) {
+        httpReq.psc = *parent_ctx;
+        copy_byte_arrays(httpReq.psc.TraceID, httpReq.sc.TraceID, TRACE_ID_SIZE);
+        generate_random_bytes(httpReq.sc.SpanID, SPAN_ID_SIZE);
+    } else {
+        httpReq.sc = generate_span_context();
+    }
     // Write event
-    httpReq.sc = generate_span_context();
     bpf_map_update_elem(&context_to_http_events, &ctx_iface, &httpReq, 0);
     long res = bpf_map_update_elem(&spans_in_progress, &ctx_iface, &httpReq.sc, 0);
     return 0;


### PR DESCRIPTION
Hi,

This PR attempts to add context propagation to the net/http server instrumentation.

We do it by iterating over the first bucket of the incoming request header map and trying to find the "traceparent" header.

This was tested with Go versions 1.12-1.19.

Our test environment consisted of instrumented Python application that sends a request to instrumented Go http server.

The produced trace looks like the following:

![image](https://user-images.githubusercontent.com/97847098/213373358-c184e90f-597c-4ca0-ba3f-52365fc89770.png)


We would love to get your feedback on this.
Thanks!