### PR TITLE
Adding net/http client instrumentor

### DIFF
--- a/include/alloc.h
+++ b/include/alloc.h
@@ -60,7 +60,7 @@ static __always_inline void* write_target_data(void* data, s32 size) {
     long success = bpf_probe_write_user(target, data, size);
     if (success == 0) {
         s32 start_index = 0;
-        u64 updated_start = start + size;
+        u64 updated_start = start + size + (8 - (size % 8));
         bpf_map_update_elem(&alloc_map, &start_index, &updated_start, BPF_ANY);
         return target;
     } else {

--- a/include/go_types.h
+++ b/include/go_types.h
@@ -5,13 +5,13 @@
 
 struct go_string {
     char* str;
-    s32 len;
+    s64 len;
 };
 
 struct go_slice {
     void* array;
-    s32 len;
-    s32 cap;
+    s64 len;
+    s64 cap;
 };
 
 struct go_slice_user_ptr {
@@ -23,6 +23,13 @@ struct go_slice_user_ptr {
 struct go_iface {
     void* tab;
     void* data;
+};
+
+struct map_bucket {
+    char tophash[8];
+    struct go_string keys[8];
+    struct go_slice values[8];
+    void* overflow;
 };
 
 static __always_inline struct go_string write_user_go_string(char* str, u32 len) {

--- a/pkg/inject/offset_results.json
+++ b/pkg/inject/offset_results.json
@@ -431,6 +431,432 @@
         },
         {
           "struct": "net/http.Request",
+          "field_name": "Header",
+          "offsets": [
+            {
+              "offset": 56,
+              "version": "1.19.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.19"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.18.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.18"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.17.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.17"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.16.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.16"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.15.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.14.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.13.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.17"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.16"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.15"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.14"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.13"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.12"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.11"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.10"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.9"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.8"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.7"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.6"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.5"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.4"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.3"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.12.1"
+            },
+            {
+              "offset": 56,
+              "version": "1.12"
+            }
+          ]
+        },
+        {
+          "struct": "net/http.Request",
           "field_name": "ctx",
           "offsets": [
             {

--- a/pkg/instrumentors/bpf/net/http/client/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/net/http/client/bpf/probe.bpf.c
@@ -1,0 +1,231 @@
+#include "arguments.h"
+#include "span_context.h"
+#include "go_context.h"
+#include "go_types.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+#define MAX_PATH_SIZE 100
+#define MAX_METHOD_SIZE 10
+#define W3C_KEY_LENGTH 11
+#define W3C_VAL_LENGTH 55
+#define MAX_CONCURRENT 50
+
+struct http_request_t {
+    u64 start_time;
+    u64 end_time;
+    char method[MAX_METHOD_SIZE];
+    char path[MAX_PATH_SIZE];
+    struct span_context sc;
+    struct span_context psc;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, void*);
+	__type(value, struct http_request_t);
+	__uint(max_entries, MAX_CONCURRENT);
+} context_to_http_events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(struct map_bucket));
+	__uint(max_entries, 1);
+} golang_mapbucket_storage_map SEC(".maps");
+
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+} events SEC(".maps");
+
+// Injected in init
+volatile const u64 method_ptr_pos;
+volatile const u64 url_ptr_pos;
+volatile const u64 path_ptr_pos;
+volatile const u64 headers_ptr_pos;
+volatile const u64 ctx_ptr_pos;
+
+
+static __always_inline int inject_header(void* headers_ptr, struct span_context* propagated_ctx) {
+
+    // Read headers map count
+    u64 map_keyvalue_count = 0;
+    bpf_probe_read(&map_keyvalue_count, sizeof(map_keyvalue_count), headers_ptr);
+
+    // Currently only maps with less than 8 keys are supported for injection
+    if (map_keyvalue_count >= 8) {
+        return 0;
+    }
+    long success;
+    if (map_keyvalue_count == 0) {
+        u32 map_id = 0;
+        struct map_bucket* map_value = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+        if (!map_value) {
+            return -1;
+        }
+        void* bucket_ptr = write_target_data(map_value, sizeof(struct map_bucket));
+        success = bpf_probe_write_user(headers_ptr + 16, &bucket_ptr, sizeof(bucket_ptr));
+
+        if(success < 0) {
+            return -1;
+        }
+
+    }
+
+    void* map_keyvalues_ptr = NULL;
+
+    bpf_probe_read(&map_keyvalues_ptr, sizeof(map_keyvalues_ptr), headers_ptr + 16);
+
+    void* injected_key_ptr = map_keyvalues_ptr + 8 + (16 * map_keyvalue_count);
+
+    char traceparent_tophash = 0xee;
+    void* tophashes_ptr = map_keyvalues_ptr +  map_keyvalue_count;
+    success = bpf_probe_write_user(tophashes_ptr, &traceparent_tophash, 1);
+
+    if(success < 0) {
+        return -1;
+    }
+
+    char key[W3C_KEY_LENGTH] = "traceparent";
+    void* ptr = write_target_data(key, W3C_KEY_LENGTH);
+
+    success = bpf_probe_write_user(injected_key_ptr, &ptr, sizeof(ptr));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    u64 header_key_length = W3C_KEY_LENGTH;
+    success = bpf_probe_write_user(injected_key_ptr + 8, &header_key_length, sizeof(header_key_length));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    void* injected_value_ptr = injected_key_ptr + (16 * (8 - map_keyvalue_count)) + 24 * map_keyvalue_count;
+
+
+
+    char val[W3C_VAL_LENGTH];
+
+    span_context_to_w3c_string(propagated_ctx, val);
+
+    ptr = write_target_data(val, sizeof(val));
+    struct go_string header_value = {};
+    header_value.str = ptr;
+    header_value.len = W3C_VAL_LENGTH;
+
+    ptr = write_target_data((void*)&header_value, sizeof(header_value));
+    success = bpf_probe_write_user(injected_value_ptr, &ptr, sizeof(ptr));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    u32 injected_num = 1;
+    success = bpf_probe_write_user(injected_value_ptr + 8, &injected_num, sizeof(injected_num));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    success = bpf_probe_write_user(injected_value_ptr + 8 + 8, &injected_num, sizeof(injected_num));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    map_keyvalue_count += 1;
+    success = bpf_probe_write_user(headers_ptr, &map_keyvalue_count, sizeof(map_keyvalue_count));
+
+    if(success < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+// This instrumentation attaches uprobe to the following function:
+// func net/http/client.Do(req *Request)
+SEC("uprobe/HttpClient")
+int uprobe_HttpClient_Do(struct pt_regs *ctx) {
+
+    struct http_request_t httpReq = {};
+    httpReq.start_time = bpf_ktime_get_ns();
+
+
+    u64 request_pos = 2;
+    void* req_ptr = get_argument(ctx, request_pos);
+
+    // Get Request.ctx
+    void *ctx_iface = 0;
+    bpf_probe_read(&ctx_iface, sizeof(ctx_iface), (void *)(req_ptr+ctx_ptr_pos+8));
+    // Get parent if exists
+    void *parent_span_ctx = find_context_in_map(ctx_iface, &spans_in_progress);
+    if (parent_span_ctx != NULL) {
+        void* psc_ptr = bpf_map_lookup_elem(&spans_in_progress, &parent_span_ctx);
+        bpf_probe_read(&httpReq.psc, sizeof(httpReq.psc), psc_ptr);
+        copy_byte_arrays(httpReq.psc.TraceID, httpReq.sc.TraceID, TRACE_ID_SIZE);
+        generate_random_bytes(httpReq.sc.SpanID, SPAN_ID_SIZE);
+    } else {
+        httpReq.sc = generate_span_context();
+    }
+
+    void* method_ptr = 0;
+    bpf_probe_read(&method_ptr, sizeof(method_ptr), (void *)(req_ptr+method_ptr_pos));
+    u64 method_len = 0;
+    bpf_probe_read(&method_len, sizeof(method_len), (void *)(req_ptr+(method_ptr_pos+8)));
+    u64 method_size = sizeof(httpReq.method);
+    method_size = method_size < method_len ? method_size : method_len;
+    bpf_probe_read(&httpReq.method, method_size, method_ptr);
+
+    // get path from Request.URL
+    void *url_ptr = 0;
+    bpf_probe_read(&url_ptr, sizeof(url_ptr), (void *)(req_ptr+url_ptr_pos));
+    void* path_ptr = 0;
+    bpf_probe_read(&path_ptr, sizeof(path_ptr), (void *)(url_ptr+path_ptr_pos));
+
+    u64 path_len = 0;
+    bpf_probe_read(&path_len, sizeof(path_len), (void *)(url_ptr+(path_ptr_pos+8)));
+    u64 path_size = sizeof(httpReq.path);
+    path_size = path_size < path_len ? path_size : path_len;
+    bpf_probe_read(&httpReq.path, path_size, path_ptr);
+
+    // get headers from Request
+    void *headers_ptr = 0;
+    bpf_probe_read(&headers_ptr, sizeof(headers_ptr), (void *)(req_ptr+headers_ptr_pos));
+    u64 map_keyvalue_count = 0;
+    bpf_probe_read(&map_keyvalue_count, sizeof(map_keyvalue_count), headers_ptr);
+    inject_header(headers_ptr, &httpReq.sc);
+
+
+
+    bpf_map_update_elem(&context_to_http_events, &ctx_iface, &httpReq, 0);
+    bpf_map_update_elem(&spans_in_progress, &ctx_iface, &httpReq.sc, 0);
+
+    return 0;
+}
+
+// This instrumentation attaches uretprobe to the following function:
+// func net/http/client.Do(req *Request)
+SEC("uprobe/HttpClient")
+int uprobe_HttpClient_Do_Returns(struct pt_regs *ctx) {
+    u64 request_pos = 2;
+    void* req_ptr = get_argument_by_stack(ctx, request_pos);
+
+    // Get Request.ctx
+    void *ctx_iface = 0;
+    bpf_probe_read(&ctx_iface, sizeof(ctx_iface), (void *)(req_ptr+ctx_ptr_pos+8));
+
+    void* httpReq_ptr = bpf_map_lookup_elem(&context_to_http_events, &ctx_iface);
+    struct http_request_t httpReq = {};
+    bpf_probe_read(&httpReq, sizeof(httpReq), httpReq_ptr);
+    httpReq.end_time = bpf_ktime_get_ns();
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
+
+    bpf_map_delete_elem(&context_to_http_events, &ctx_iface);
+    bpf_map_delete_elem(&spans_in_progress, &ctx_iface);
+
+    return 0;
+}

--- a/pkg/instrumentors/bpf/net/http/client/probe.go
+++ b/pkg/instrumentors/bpf/net/http/client/probe.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/perf"
+	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/inject"
+	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpffs"
+	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/context"
+	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/events"
+	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/log"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target bpfel -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
+
+type HttpEvent struct {
+	StartTime         uint64
+	EndTime           uint64
+	Method            [10]byte
+	Path              [100]byte
+	SpanContext       context.EbpfSpanContext
+	ParentSpanContext context.EbpfSpanContext
+}
+
+type httpServerInstrumentor struct {
+	bpfObjects   *bpfObjects
+	uprobe       link.Link
+	returnProbs  []link.Link
+	eventsReader *perf.Reader
+}
+
+func New() *httpServerInstrumentor {
+	return &httpServerInstrumentor{}
+}
+
+func (h *httpServerInstrumentor) LibraryName() string {
+	return "net/http/client"
+}
+
+func (h *httpServerInstrumentor) FuncNames() []string {
+	return []string{"net/http.(*Client).do"}
+}
+
+func (h *httpServerInstrumentor) Load(ctx *context.InstrumentorContext) error {
+	spec, err := ctx.Injector.Inject(loadBpf, "go", ctx.TargetDetails.GoVersion.Original(), []*inject.InjectStructField{
+		{
+			VarName:    "method_ptr_pos",
+			StructName: "net/http.Request",
+			Field:      "Method",
+		},
+		{
+			VarName:    "url_ptr_pos",
+			StructName: "net/http.Request",
+			Field:      "URL",
+		},
+		{
+			VarName:    "ctx_ptr_pos",
+			StructName: "net/http.Request",
+			Field:      "ctx",
+		},
+		{
+			VarName:    "path_ptr_pos",
+			StructName: "net/url.URL",
+			Field:      "Path",
+		},
+		{
+			VarName:    "headers_ptr_pos",
+			StructName: "net/http.Request",
+			Field:      "Header",
+		},
+	}, true)
+
+	if err != nil {
+		return err
+	}
+
+	h.bpfObjects = &bpfObjects{}
+	err = spec.LoadAndAssign(h.bpfObjects, &ebpf.CollectionOptions{
+		Maps: ebpf.MapOptions{
+			PinPath: bpffs.BpfFsPath,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	offset, err := ctx.TargetDetails.GetFunctionOffset(h.FuncNames()[0])
+
+	up, err := ctx.Executable.Uprobe("", h.bpfObjects.UprobeHttpClientDo, &link.UprobeOptions{
+		Offset: offset,
+	})
+	if err != nil {
+		return err
+	}
+
+	h.uprobe = up
+
+	retOffsets, err := ctx.TargetDetails.GetFunctionReturns(h.FuncNames()[0])
+
+	if err != nil {
+		return err
+	}
+
+	for _, ret := range retOffsets {
+		retProbe, err := ctx.Executable.Uprobe("", h.bpfObjects.UprobeHttpClientDoReturns, &link.UprobeOptions{
+			Offset: ret,
+		})
+		if err != nil {
+			return err
+		}
+		h.returnProbs = append(h.returnProbs, retProbe)
+	}
+
+	rd, err := perf.NewReader(h.bpfObjects.Events, os.Getpagesize())
+	if err != nil {
+		return err
+	}
+	h.eventsReader = rd
+
+	return nil
+}
+
+func (h *httpServerInstrumentor) Run(eventsChan chan<- *events.Event) {
+	logger := log.Logger.WithName("net/http/client-instrumentor")
+	var event HttpEvent
+	for {
+		record, err := h.eventsReader.Read()
+		if err != nil {
+			if errors.Is(err, perf.ErrClosed) {
+				return
+			}
+			logger.Error(err, "error reading from perf reader")
+			continue
+		}
+
+		if record.LostSamples != 0 {
+			logger.V(0).Info("perf event ring buffer full", "dropped", record.LostSamples)
+			continue
+		}
+
+		if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &event); err != nil {
+			logger.Error(err, "error parsing perf event")
+			continue
+		}
+
+		eventsChan <- h.convertEvent(&event)
+	}
+}
+
+func (h *httpServerInstrumentor) convertEvent(e *HttpEvent) *events.Event {
+	method := unix.ByteSliceToString(e.Method[:])
+	path := unix.ByteSliceToString(e.Path[:])
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    e.SpanContext.TraceID,
+		SpanID:     e.SpanContext.SpanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	var pscPtr *trace.SpanContext
+	if e.ParentSpanContext.TraceID.IsValid() {
+		psc := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    e.ParentSpanContext.TraceID,
+			SpanID:     e.ParentSpanContext.SpanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		pscPtr = &psc
+	} else {
+		pscPtr = nil
+	}
+
+	return &events.Event{
+		Library:     h.LibraryName(),
+		Name:        path,
+		Kind:        trace.SpanKindServer,
+		StartTime:   int64(e.StartTime),
+		EndTime:     int64(e.EndTime),
+		SpanContext: &sc,
+		Attributes: []attribute.KeyValue{
+			semconv.HTTPMethodKey.String(method),
+			semconv.HTTPTargetKey.String(path),
+		},
+		ParentSpanContext: pscPtr,
+	}
+}
+
+func (h *httpServerInstrumentor) Close() {
+	log.Logger.V(0).Info("closing net/http/client instrumentor")
+	if h.eventsReader != nil {
+		h.eventsReader.Close()
+	}
+
+	if h.uprobe != nil {
+		h.uprobe.Close()
+	}
+
+	for _, r := range h.returnProbs {
+		r.Close()
+	}
+
+	if h.bpfObjects != nil {
+		h.bpfObjects.Close()
+	}
+}

--- a/pkg/instrumentors/manager.go
+++ b/pkg/instrumentors/manager.go
@@ -6,6 +6,7 @@ import (
 	gorillaMux "github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpf/github.com/gorilla/mux"
 	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpf/google/golang/org/grpc"
 	grpcServer "github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpf/google/golang/org/grpc/server"
+	httpClient "github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpf/net/http/client"
 	httpServer "github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/bpf/net/http/server"
 	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/instrumentors/events"
 	"github.com/keyval-dev/opentelemetry-go-instrumentation/pkg/log"
@@ -86,6 +87,7 @@ func registerInstrumentors(m *instrumentorsManager) error {
 		grpcServer.New(),
 		httpServer.New(),
 		gorillaMux.New(),
+		httpClient.New(),
 	}
 
 	for _, i := range insts {


### PR DESCRIPTION
Hi,

This PR attempts to add instrumentation for net/http client.

We do it by writing a fake tophash value (as calculating the correct one will be harder to achieve) to the first headers map bucket and writing the "traceparent" header key and value into memory.

This was tested with Go versions 1.12-1.19.

Our test environment consisted of instrumented Python application that sends a request to instrumented Go http server which in turn sends an http request to an additional instrumented Go http server.

The produced trace looks like the following:

![image](https://user-images.githubusercontent.com/97847098/213374473-d266bf1f-49f5-4f8c-8e0d-53ed51d80201.png)


We would love to get your feedback on this.
Thanks!